### PR TITLE
Tempo needs to be updated before getting the next event

### DIFF
--- a/lib/midi_file_player.dart
+++ b/lib/midi_file_player.dart
@@ -149,15 +149,16 @@ class MidiFilePlayer {
 
         if (nextTrackPlayer != null) {
           final event = nextTrackPlayer.current(currentDeltaTimeUnitInMillis);
+          final midiEvent = event.midiEvent;
+          if (midiEvent is TempoEvent) {
+            _setCurrentTempoEvent(midiEvent);
+          }
+
           // if no next, remove track
           if (nextTrackPlayer.next(currentDeltaTimeUnitInMillis) == null) {
             trackPlayers.remove(nextTrackPlayer);
           }
 
-          final midiEvent = event.midiEvent;
-          if (midiEvent is TempoEvent) {
-            _setCurrentTempoEvent(midiEvent);
-          }
           _locatedEvents.add(event);
         } else {
           break;


### PR DESCRIPTION
I encountered a bug that the absoluteMs value is set incorrectly for some events directly following the tempo change event.